### PR TITLE
Chore: Remove github actions push command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   specs:
     name: specs


### PR DESCRIPTION
The initial setup for github actions was to run rspec and rubocop on
push to github and on creating a pull request which mean they were being
run twice. This removes the setting to run them on push and the checks
will now only run on pull request on github