### PR TITLE
Enum categories

### DIFF
--- a/app/models/benefit.rb
+++ b/app/models/benefit.rb
@@ -1,17 +1,9 @@
 class Benefit < ApplicationRecord
-  CATEGORIES =
-    %w[
-      inpatient
-      outpatient
-      therapists
-      medicines_and_appliances
-      wellness
-      evacuation_and_repatriation
-      maternity
-      dental
-      optical
-      additional
-    ].freeze
+  enum category: { inpatient: 0, outpatient: 1, therapists: 2,
+                   medicines_and_appliances: 3, wellness: 4,
+                   evacuation_and_repatriation: 5, maternity: 6,
+                   dental: 7, optical: 8, additional: 9 }
+
   validates :name, presence: true, uniqueness: { scope: :category, case_sensitive: false }
-  validates :category, presence: true, inclusion: { in: CATEGORIES }
+  validates :category, presence: true
 end

--- a/db/migrate/20200727212421_change_category_to_be_integer_in_benefits.rb
+++ b/db/migrate/20200727212421_change_category_to_be_integer_in_benefits.rb
@@ -1,0 +1,9 @@
+class ChangeCategoryToBeIntegerInBenefits < ActiveRecord::Migration[6.0]
+  def up
+    change_column :benefits, :category, :integer, using: 'category::integer'
+  end
+
+  def down
+    change_column :benefits, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_205642) do
+ActiveRecord::Schema.define(version: 2020_07_27_212421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "benefits", force: :cascade do |t|
     t.string "name", null: false
-    t.string "category", null: false
+    t.integer "category", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name", "category"], name: "index_benefits_on_name_and_category", unique: true

--- a/spec/factories/benefits.rb
+++ b/spec/factories/benefits.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :benefit do
-    name { 'surgery' }
+    name { Faker::Commerce.product_name }
     category { 'inpatient' }
   end
 end

--- a/spec/models/benefit_spec.rb
+++ b/spec/models/benefit_spec.rb
@@ -1,10 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Benefit, type: :model do
+  subject(:benefit) { create(:benefit) }
+
   before { create(:benefit) }
 
-  it { is_expected.to validate_presence_of :name }
-  it { is_expected.to validate_uniqueness_of(:name).case_insensitive.scoped_to(:category) }
-  it { is_expected.to validate_presence_of :category }
-  it { is_expected.to validate_inclusion_of(:category).in_array(Benefit::CATEGORIES) }
+  it { expect(benefit).to validate_presence_of :name }
+  it { expect(benefit).to validate_uniqueness_of(:name).case_insensitive.scoped_to(:category) }
+  it { expect(benefit).to validate_presence_of :category }
+
+  it do
+    expect(benefit).to define_enum_for(:category)
+      .with_values(%w[inpatient outpatient therapists medicines_and_appliances wellness
+                      evacuation_and_repatriation maternity dental optical additional])
+  end
 end


### PR DESCRIPTION
Changes the category column on benefits to an enum type to better define the field types that can go into the column. This also allows rails_admin to create dropdown boxes of possible options