### PR TITLE
Product module categories

### DIFF
--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -1,14 +1,6 @@
 class ProductModule < ApplicationRecord
-  CATEGORIES =
-    %w[
-      core
-      outpatient
-      medicines_and_appliances
-      wellness
-      maternity
-      dental_and_optical
-      evacuation_and_repatriation
-    ].freeze
+  enum category: { core: 0, outpatient: 1, medicines_and_appliances: 2, wellness: 3,
+                   maternity: 4, dental_and_optical: 5, evacuation_and_repatriation: 6 }
   VALID_CURRENCY = /
                     \A(eur|gbp|usd)\s?\d+,?\d*,?\d*\s?\|?\s?
                     (eur|gbp|usd)\s?\d+,?\d*,?\d*\s?\|?\s?
@@ -17,7 +9,7 @@ class ProductModule < ApplicationRecord
 
   belongs_to :product
   validates :name, presence: true, uniqueness: { scope: :category, case_sensitive: false }
-  validates :category, presence: true, inclusion: { in: CATEGORIES }
+  validates :category, presence: true
   validates :sum_assured,
             presence: true,
             format: { with: VALID_CURRENCY,

--- a/db/migrate/20200727221826_change_category_to_be_integer_in_product_modules.rb
+++ b/db/migrate/20200727221826_change_category_to_be_integer_in_product_modules.rb
@@ -1,0 +1,9 @@
+class ChangeCategoryToBeIntegerInProductModules < ActiveRecord::Migration[6.0]
+  def up
+    change_column :product_modules, :category, :integer, using: 'category::integer'
+  end
+
+  def down
+    change_column :product_module, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_27_212421) do
+ActiveRecord::Schema.define(version: 2020_07_27_221826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_212421) do
 
   create_table "product_modules", force: :cascade do |t|
     t.string "name", null: false
-    t.string "category", null: false
+    t.integer "category", null: false
     t.string "sum_assured", null: false
     t.bigint "product_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/insurers.rb
+++ b/spec/factories/insurers.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :insurer do
-    name { 'BUPA Global' }
+    name { Faker::Company.name }
   end
 end

--- a/spec/factories/product_modules.rb
+++ b/spec/factories/product_modules.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :product_module do
-    name { 'Gold' }
+    name { Faker::Commerce.product_name }
     category { 'core' }
     sum_assured { 'USD 3,000,000 | EUR 3,200,000 | GBP 2,500,000' }
     product

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :product do
-    name { 'Lifeline' }
+    name { Faker::Company.name }
     insurer
   end
 end

--- a/spec/models/product_module_spec.rb
+++ b/spec/models/product_module_spec.rb
@@ -1,13 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe ProductModule, type: :model do
+  subject(:product_module) { create(:product_module) }
+
   before { create(:product_module) }
 
-  it { is_expected.to validate_presence_of :name }
-  it { is_expected.to validate_uniqueness_of(:name).case_insensitive.scoped_to(:category) }
-  it { is_expected.to validate_presence_of :category }
-  it { is_expected.to validate_inclusion_of(:category).in_array(ProductModule::CATEGORIES) }
-  it { is_expected.to validate_presence_of :sum_assured }
-  it { is_expected.to allow_value('USD 5,00 | GBP 6,00 | EUR 7,00').for(:sum_assured) }
-  it { is_expected.not_to allow_value('USD 5,00 | GBP 6,00 | EUR 7,00 | TNT 5,00').for(:sum_assured) }
+  it { expect(product_module).to validate_presence_of :name }
+  it { expect(product_module).to validate_uniqueness_of(:name).case_insensitive.scoped_to(:category) }
+  it { expect(product_module).to validate_presence_of :category }
+  it { expect(product_module).to validate_presence_of :sum_assured }
+  it { expect(product_module).to allow_value('USD 5,00 | GBP 6,00 | EUR 7,00').for(:sum_assured) }
+  it { expect(product_module).not_to allow_value('USD 5,00 | GBP 6,00 | EUR 7,00 | TNT 5,00').for(:sum_assured) }
+
+  it do
+    expect(product_module).to define_enum_for(:category)
+      .with_values(%w[core outpatient medicines_and_appliances wellness
+                      maternity dental_and_optical evacuation_and_repatriation])
+  end
 end


### PR DESCRIPTION
Adds an enum type to the category column of ProductModules

The main benefit of this is keeping code cleaner and allows rails_admin to create dropdown boxes for the product module category field when creating a new product module

Specs have been updated to reflect this change and an explicit subject is now used in the product module model tests