### PR TITLE
Fix enum values

### DIFF
--- a/app/models/benefit.rb
+++ b/app/models/benefit.rb
@@ -1,8 +1,8 @@
 class Benefit < ApplicationRecord
-  enum category: { inpatient: 0, outpatient: 1, therapists: 2,
-                   medicines_and_appliances: 3, wellness: 4,
-                   evacuation_and_repatriation: 5, maternity: 6,
-                   dental: 7, optical: 8, additional: 9 }
+  enum category: { 'inpatient' => 0, 'outpatient' => 1, 'therapists' => 2,
+                   'medicines and appliances' => 3, 'wellness' => 4,
+                   'evacuation and repatriation' => 5, 'maternity' => 6,
+                   'dental' => 7, 'optical' => 8, 'additional' => 9 }
 
   validates :name, presence: true, uniqueness: { scope: :category, case_sensitive: false }
   validates :category, presence: true

--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -1,6 +1,6 @@
 class ProductModule < ApplicationRecord
-  enum category: { core: 0, outpatient: 1, medicines_and_appliances: 2, wellness: 3,
-                   maternity: 4, dental_and_optical: 5, evacuation_and_repatriation: 6 }
+  enum category: { 'core' => 0, 'outpatient' => 1, 'medicines and appliances' => 2, 'wellness' => 3,
+                   'maternity' => 4, 'dental and optical' => 5, 'evacuation and repatriation' => 6 }
   VALID_CURRENCY = /
                     \A(eur|gbp|usd)\s?\d+,?\d*,?\d*\s?\|?\s?
                     (eur|gbp|usd)\s?\d+,?\d*,?\d*\s?\|?\s?

--- a/spec/models/benefit_spec.rb
+++ b/spec/models/benefit_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Benefit, type: :model do
 
   it do
     expect(benefit).to define_enum_for(:category)
-      .with_values(%w[inpatient outpatient therapists medicines_and_appliances wellness
-                      evacuation_and_repatriation maternity dental optical additional])
+      .with_values(['inpatient', 'outpatient', 'therapists', 'medicines and appliances',
+                    'wellness', 'evacuation and repatriation', 'maternity', 'dental',
+                    'optical', 'additional'])
   end
 end

--- a/spec/models/product_module_spec.rb
+++ b/spec/models/product_module_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProductModule, type: :model do
 
   it do
     expect(product_module).to define_enum_for(:category)
-      .with_values(%w[core outpatient medicines_and_appliances wellness
-                      maternity dental_and_optical evacuation_and_repatriation])
+      .with_values(['core', 'outpatient', 'medicines and appliances', 'wellness', 'maternity',
+                    'dental and optical', 'evacuation and repatriation'])
   end
 end


### PR DESCRIPTION
Fix: Converts benefit and product module model category enum keys to strings

As the enum values are used by rails admin to create a dropdown of possible values these commits change the enum keys from symbols to strings.