### PR TITLE
Product module benefits

### DIFF
--- a/app/models/product_module_benefit.rb
+++ b/app/models/product_module_benefit.rb
@@ -1,0 +1,4 @@
+class ProductModuleBenefit < ApplicationRecord
+  belongs_to :product_module
+  belongs_to :benefit
+end

--- a/app/models/product_module_benefit.rb
+++ b/app/models/product_module_benefit.rb
@@ -1,4 +1,10 @@
 class ProductModuleBenefit < ApplicationRecord
   belongs_to :product_module
   belongs_to :benefit
+
+  enum benefit_status: { 'paid in full' => 0, 'capped benefit' => 1 }
+
+  validates :benefit_status, presence: true
+  validates :benefit_limit, presence: true
+  validates :product_module_id, uniqueness: { scope: :benefit_id }
 end

--- a/db/migrate/20200729205617_create_product_module_benefits.rb
+++ b/db/migrate/20200729205617_create_product_module_benefits.rb
@@ -1,0 +1,15 @@
+class CreateProductModuleBenefits < ActiveRecord::Migration[6.0]
+  def change
+    create_table :product_module_benefits do |t|
+      t.references :product_module, null: false, foreign_key: true
+      t.references :benefit, null: false, foreign_key: true
+      t.integer :benefit_status, null: false
+      t.string :benefit_limit, null: false
+      t.text :explanation_of_benefit
+
+      t.timestamps
+    end
+    add_index :product_module_benefits, %i[product_module_id benefit_id],
+              unique: true, name: 'index_product_module_benefits_on_product_module_and_benefit'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_27_221826) do
+ActiveRecord::Schema.define(version: 2020_07_29_205617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,19 @@ ActiveRecord::Schema.define(version: 2020_07_27_221826) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_insurers_on_name", unique: true
+  end
+
+  create_table "product_module_benefits", force: :cascade do |t|
+    t.bigint "product_module_id", null: false
+    t.bigint "benefit_id", null: false
+    t.integer "benefit_status", null: false
+    t.string "benefit_limit", null: false
+    t.text "explanation_of_benefit"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["benefit_id"], name: "index_product_module_benefits_on_benefit_id"
+    t.index ["product_module_id", "benefit_id"], name: "index_product_module_benefits_on_product_module_and_benefit", unique: true
+    t.index ["product_module_id"], name: "index_product_module_benefits_on_product_module_id"
   end
 
   create_table "product_modules", force: :cascade do |t|
@@ -75,6 +88,8 @@ ActiveRecord::Schema.define(version: 2020_07_27_221826) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "product_module_benefits", "benefits"
+  add_foreign_key "product_module_benefits", "product_modules"
   add_foreign_key "product_modules", "products"
   add_foreign_key "products", "insurers"
 end

--- a/spec/factories/product_module_benefits.rb
+++ b/spec/factories/product_module_benefits.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :product_module_benefit do
+    product_module
+    benefit
+    benefit_status { 1 }
+    benefit_limit { ' USD 1,000,000 | EUR 1,000,000 | GBP 850,000' }
+    explanation_of_benefit { 'Within overall limit' }
+  end
+end

--- a/spec/models/product_module_benefit_spec.rb
+++ b/spec/models/product_module_benefit_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProductModuleBenefit, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/product_module_benefit_spec.rb
+++ b/spec/models/product_module_benefit_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe ProductModuleBenefit, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject(:product_module_benefit) { create(:product_module_benefit) }
+
+  it { expect(product_module_benefit).to belong_to :product_module }
+  it { expect(product_module_benefit).to belong_to :benefit }
+  it { expect(product_module_benefit).to validate_presence_of :benefit_status }
+  it { expect(product_module_benefit).to validate_presence_of :benefit_limit }
+  it { expect(product_module_benefit).to validate_uniqueness_of(:product_module_id).scoped_to(:benefit_id) }
+  it { expect(product_module_benefit).to define_enum_for(:benefit_status).with_values(['paid in full', 'capped benefit']) }
 end


### PR DESCRIPTION
Feature: Product Module Benefit model

Joins the ProductModule and Benefit tables and adds benefit_status, benefit_limit and explanation_of_benefit fields.

This allow the system to build product modules with benefits that will make up products to represent international health insurance policies.

benefit_status is an enum mapping "paid in full" and "capped benefit" values. These will be used to colour-code comparison tables