### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,22 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
+    allow:
+      - dependency-type: "all"
     schedule:
       interval: "daily"
     target-branch: "master"
     commit-message:
       prefix: "chore"
+    open-pull-requests-limit: 10
 
   - package-ecosystem: "bundler"
     directory: "/"
+    allow:
+      - dependency-type: "all"
     schedule:
       interval: "daily"
     target-branch: "master"
     commit-message:
       prefix: "chore"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Because: I want to allow dependabot to update all gems and schedule more
pull requests

This commit: Adds the option to update all packages and increases the
pull request limit from 5 to 10