### PR TITLE
Create module benefits

### DIFF
--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -8,7 +8,7 @@ class ProductModule < ApplicationRecord
                    /ix.freeze
 
   belongs_to :product
-  has_many :product_module_benefits, dependent: :destroy
+  has_many :product_module_benefits, dependent: :destroy, inverse_of: :product_module
 
   validates :name, presence: true, uniqueness: { scope: :category, case_sensitive: false }
   validates :category, presence: true

--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -8,6 +8,8 @@ class ProductModule < ApplicationRecord
                    /ix.freeze
 
   belongs_to :product
+  has_many :product_module_benefits, dependent: :destroy
+
   validates :name, presence: true, uniqueness: { scope: :category, case_sensitive: false }
   validates :category, presence: true
   validates :sum_assured,

--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -16,4 +16,6 @@ class ProductModule < ApplicationRecord
             presence: true,
             format: { with: VALID_CURRENCY,
                       message: 'Please write the sum assured in the format "USD X,XXX,XXX | GBP X,XXX,XXX | EUR X,XXX,XXX"' }
+
+  accepts_nested_attributes_for :product_module_benefits
 end

--- a/app/models/product_module_benefit.rb
+++ b/app/models/product_module_benefit.rb
@@ -1,5 +1,5 @@
 class ProductModuleBenefit < ApplicationRecord
-  belongs_to :product_module
+  belongs_to :product_module, inverse_of: :product_module_benefits
   belongs_to :benefit
 
   enum benefit_status: { 'paid in full' => 0, 'capped benefit' => 1 }

--- a/spec/models/product_module_spec.rb
+++ b/spec/models/product_module_spec.rb
@@ -17,4 +17,6 @@ RSpec.describe ProductModule, type: :model do
       .with_values(['core', 'outpatient', 'medicines and appliances', 'wellness', 'maternity',
                     'dental and optical', 'evacuation and repatriation'])
   end
+
+  it { expect(product_module).to have_many(:product_module_benefits).dependent(:destroy) }
 end

--- a/spec/models/product_module_spec.rb
+++ b/spec/models/product_module_spec.rb
@@ -19,4 +19,5 @@ RSpec.describe ProductModule, type: :model do
   end
 
   it { expect(product_module).to have_many(:product_module_benefits).dependent(:destroy) }
+  it { expect(product_module).to accept_nested_attributes_for(:product_module_benefits) }
 end


### PR DESCRIPTION
This allows product module benefits to be created through product modules in the admin dashboard and means product module benefits can be rapidly created through product modules.

The inverse_of option was set on the associations to allow rails_admin to hide the product_module field in the product_module_benefits nested form.