### PR TITLE
Dependent destroy

### DIFF
--- a/app/models/insurer.rb
+++ b/app/models/insurer.rb
@@ -1,3 +1,5 @@
 class Insurer < ApplicationRecord
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+
+  has_many :products, dependent: :destroy
 end

--- a/app/models/insurer.rb
+++ b/app/models/insurer.rb
@@ -1,5 +1,5 @@
 class Insurer < ApplicationRecord
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
-
   has_many :products, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,7 @@
 class Product < ApplicationRecord
   belongs_to :insurer
+  has_many :product_modules, dependent: :destroy
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :insurer, presence: true
 end

--- a/spec/models/insurer_spec.rb
+++ b/spec/models/insurer_spec.rb
@@ -7,4 +7,5 @@ RSpec.describe Insurer, type: :model do
 
   it { expect(insurer).to validate_presence_of :name }
   it { expect(insurer).to validate_uniqueness_of(:name).case_insensitive }
+  it { expect(insurer).to have_many(:products).dependent(:destroy) }
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -9,4 +9,5 @@ RSpec.describe Product, type: :model do
   it { expect(product).to validate_presence_of :name }
   it { expect(product).to validate_uniqueness_of(:name).case_insensitive }
   it { expect(product).to validate_presence_of :insurer }
+  it { expect(product).to have_many(:product_modules).dependent(:destroy) }
 end


### PR DESCRIPTION
Adds dependent destroy option on relevant associations

The following associations require that the associated model be destroyed when the parent model is deleted

Insurer -> Product
Product -> Product Module
Product Module -> Product Module Benefit

This is addressed in this pull request.