### PR TITLE
Excel output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,10 +30,14 @@ gem 'jbuilder', '~> 2.7'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false
 
+gem 'axlsx_styler'
 gem 'cancancan'
+gem 'caxlsx'
+gem 'caxlsx_rails'
 gem 'devise'
 gem 'devise_invitable', '~> 2.0.0'
 gem 'rails_admin', '~> 2.0'
+gem 'rubyzip'
 gem 'undercover'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development do
   gem 'guard-rails', require: false
   gem 'guard-rspec', require: false
   gem 'guard-rubocop'
+  gem 'guard-webpacker', require: false
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,9 @@ GEM
     guard-rubocop (1.3.0)
       guard (~> 2.0)
       rubocop (~> 0.20)
+    guard-webpacker (0.2.1)
+      guard (>= 2)
+      guard-compat (~> 1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -392,6 +395,7 @@ DEPENDENCIES
   guard-rails
   guard-rspec
   guard-rubocop
+  guard-webpacker
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    axlsx_styler (1.1.0)
+      activesupport (>= 3.1)
+      caxlsx (>= 2.0.2)
     bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.6)
@@ -84,6 +87,14 @@ GEM
     capybara-screenshot (1.0.24)
       capybara (>= 1.0, < 4)
       launchy
+    caxlsx (3.0.2)
+      htmlentities (~> 4.3, >= 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
+    caxlsx_rails (0.6.2)
+      actionpack (>= 3.1)
+      caxlsx (>= 3.0)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
@@ -142,6 +153,7 @@ GEM
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
+    htmlentities (4.3.4)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     imagen (0.1.8)
@@ -380,11 +392,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  axlsx_styler
   bootsnap (>= 1.4.2)
   bullet (~> 6.1.0)
   byebug
   cancancan
   capybara-screenshot
+  caxlsx
+  caxlsx_rails
   database_cleaner
   devise
   devise_invitable (~> 2.0.0)
@@ -408,6 +423,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubyzip
   sass-rails (>= 6)
   selenium-webdriver
   shoulda-matchers

--- a/Guardfile
+++ b/Guardfile
@@ -108,3 +108,14 @@ guard :rubocop do
   watch(/.+\.rb$/)
   watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
 end
+
+### Guard::Webpacker
+#  available options:
+#  - :bin (defaults to "webpack-dev-server") to run
+#  - :watch (defaults to "default") can be an array
+#  - :colors (defaults to 1)
+#  - :progress
+guard :webpacker do
+  watch('config/webpacker.yml')
+  watch(%r{^config/webpacker/(.+)$})
+end

--- a/app/controllers/comparisons_controller.rb
+++ b/app/controllers/comparisons_controller.rb
@@ -1,6 +1,34 @@
 class ComparisonsController < ApplicationController
   def new
-    @benefits = Benefit.grouped_by_category
-    @benefit_categories = @benefits.keys
+    @grouped_benefits = Benefit.grouped_by_category
+    @benefit_categories = Benefit.categories.keys.select { @grouped_benefits.key? _1 }
+  end
+
+  def show
+    @comparison_products = comparison_products(params[:selected_products])
+    @grouped_benefits = Benefit.grouped_by_category
+    @benefit_categories = Benefit.categories.keys.select { @grouped_benefits.key? _1 }
+
+    respond_to do |format|
+      format.xlsx do
+        response.headers['Content-Disposition'] = 'attachment; filename="comparison.xlsx"'
+      end
+    end
+  end
+
+  private
+
+  def comparison_products(selected_products)
+    selected_products.map do |selected_product|
+      ComparisonProduct.new(
+        Insurer.find(selected_product[:insurer]),
+        Product.find(selected_product[:product]),
+        ProductModule.includes(:product_module_benefits).find(selected_modules(selected_product[:product_modules]))
+      )
+    end
+  end
+
+  def selected_modules(modules)
+    modules.values.flatten
   end
 end

--- a/app/javascript/controllers/comparison_export_controller.js
+++ b/app/javascript/controllers/comparison_export_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "stimulus";
+
+export default class extends Controller {
+  static targets = ["productDetailsJSON", "productDetailJSON"]
+
+  excelExport(event) {
+    const queryParams = this.parameterise()
+    console.log(queryParams)
+    const url = `/comparisons/show.xlsx?${queryParams}`
+    window.location = url
+  }
+
+  parameterise() {
+    return this.productDetailJSONTargets.map(target => {
+      const dataParams = JSON.parse(target.dataset.productDetails)
+      return this.queryString(dataParams)
+    }).join("&")
+  }
+
+  queryString(dataParams) {
+    return Object.entries(dataParams).map(([key, val]) => {
+      if(typeof val === "object") {
+        return Object.entries(val).map(([key2, val2]) => encodeURI(`selected_products[][${key}][${key2}]=${val2}`)).join('&')
+      } else {
+        return(encodeURI(`selected_products[][${key}]=${val}`))
+      }
+    }).join("&")
+  }
+}
+

--- a/app/javascript/controllers/comparison_product_controller.js
+++ b/app/javascript/controllers/comparison_product_controller.js
@@ -3,10 +3,11 @@ import ComparisonProduct from "../services/comparison_product"
 import NullProductModuleBenefit from "../nulls/null_product_module_benefit"
 
 export default class extends Controller {
-  static targets = ["insurer", "product", "productModules", "comparisonProductSubmit", "insurerTableRow", "productTableRow", "chosenCoverRow", "overallSumAssured", "benefitRow"]
+  static targets = ["insurer", "product", "productModules", "comparisonProductSubmit", "insurerTableRow", "productTableRow", "chosenCoverRow", "overallSumAssured", "benefitRow", "productDetailsJSON"]
 
   addComparisonProduct(event) {
     event.preventDefault()
+    this.selectedProductDetails = JSON.stringify(this.submissionData())
 
     fetch(`/comparison_products`, {
       method: 'POST',
@@ -14,7 +15,7 @@ export default class extends Controller {
         'X-CSRF-Token': this.crsfToken(),
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(this.submissionData()),
+      body: this.selectedProductDetails,
     })
       .then(response => response.json())
       .then(data => this.addSelectedProductToComparison(data)) 
@@ -22,6 +23,7 @@ export default class extends Controller {
 
   addSelectedProductToComparison(data) {
     this.comparisonProduct = new ComparisonProduct(data['insurer'], data['product'], data['product_modules'])
+    this.addSelectedProductDetails()
     this.addInsurer()
     this.addProduct()
     this.addChosenCover()
@@ -46,6 +48,11 @@ export default class extends Controller {
   selectedProductModules() {
     let productModules = Array.from(this.productModulesTarget.querySelectorAll("input[type=radio]:checked"))
     return productModules.map(module => module.value)
+  }
+
+  addSelectedProductDetails() {
+    const cell = this.productDetailsJSONTarget.insertCell()
+    cell.dataset.productDetails = this.selectedProductDetails
   }
 
   addInsurer() {

--- a/app/javascript/controllers/comparison_product_controller.js
+++ b/app/javascript/controllers/comparison_product_controller.js
@@ -53,6 +53,7 @@ export default class extends Controller {
   addSelectedProductDetails() {
     const cell = this.productDetailsJSONTarget.insertCell()
     cell.dataset.productDetails = this.selectedProductDetails
+    cell.dataset.target = "comparison-export.productDetailJSON"
   }
 
   addInsurer() {

--- a/app/javascript/styles/blocks/table/table.scss
+++ b/app/javascript/styles/blocks/table/table.scss
@@ -1,3 +1,7 @@
+.table__tbody--hidden {
+  display: none;
+}
+
 .table--sticky-col {
   position: -webkit-sticky;
   position: sticky;

--- a/app/models/product_module_benefit.rb
+++ b/app/models/product_module_benefit.rb
@@ -7,4 +7,12 @@ class ProductModuleBenefit < ApplicationRecord
   validates :benefit_status, presence: true
   validates :benefit_limit, presence: true
   validates :product_module_id, uniqueness: { scope: :benefit_id }
+
+  def full_benefit_coverage
+    <<~BENEFIT.strip
+      #{benefit_limit}
+
+      #{explanation_of_benefit}
+    BENEFIT
+  end
 end

--- a/app/nulls/null_product_module_benefit.rb
+++ b/app/nulls/null_product_module_benefit.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class NullProductModuleBenefit
+  def icon
+    "<span class='icon'><i class='fa fa-times red-cross'></i></span>"
+  end
+
+  def benefit_limit
+    'Not covered'
+  end
+
+  def explanation_of_benefit
+    'Not Covered'
+  end
+
+  def benefit_status
+    'not covered'
+  end
+end

--- a/app/nulls/null_product_module_benefit.rb
+++ b/app/nulls/null_product_module_benefit.rb
@@ -16,4 +16,6 @@ class NullProductModuleBenefit
   def benefit_status
     'not covered'
   end
+
+  alias full_benefit_coverage explanation_of_benefit
 end

--- a/app/services/comparison_product.rb
+++ b/app/services/comparison_product.rb
@@ -6,4 +6,17 @@ class ComparisonProduct
     @product = product
     @product_modules = product_modules
   end
+
+  def product_module_names
+    product_modules.map(&:name).join(' + ')
+  end
+
+  def overall_sum_assured
+    product_modules.find { |product_module| product_module.category == 'core' }
+                   .sum_assured
+  end
+
+  def module_benefits
+    product_modules.map(&:product_module_benefits).flatten
+  end
 end

--- a/app/views/comparisons/new.html.erb
+++ b/app/views/comparisons/new.html.erb
@@ -32,6 +32,11 @@
     </div>
     <div class="table-container column columns__column--no-padding-left">
       <table class="table">
+        <tbody class="table__tbody--hidden">
+          <tr data-target="comparison-product.productDetailsJSON">
+            <td></td>
+          </tr>
+        </tbody>
         <tbody>
           <tr>
             <th class="table--sticky-col table--fixed-col-width">Product Details</th>

--- a/app/views/comparisons/new.html.erb
+++ b/app/views/comparisons/new.html.erb
@@ -67,5 +67,11 @@
           <% end %>
       </table>
     </div>
+    <div class="column is-2 has-text-centered">
+      <h3 class="subtitle is-3">Export</h3>
+      <button class="button is-large">
+        <span class="icon is-medium"><i class="fas fa-file-excel"></i></span>
+      </button>
+    </div>
   </div>
 </section>

--- a/app/views/comparisons/new.html.erb
+++ b/app/views/comparisons/new.html.erb
@@ -1,5 +1,5 @@
 <section class="section">
-  <div class="columns" data-controller="comparison-product">
+  <div class="columns" data-controller="comparison-product comparison-export">
     <div class="column is-one-fifth">
       <h3 class="title is-3">Product Picker</h3>
       <div data-controller="health-comparison-product-select">
@@ -33,7 +33,7 @@
     <div class="table-container column columns__column--no-padding-left">
       <table class="table">
         <tbody class="table__tbody--hidden">
-          <tr data-target="comparison-product.productDetailsJSON">
+          <tr data-target="comparison-product.productDetailsJSON comparison-export.productDetailsJSON">
             <td></td>
           </tr>
         </tbody>
@@ -63,7 +63,7 @@
               </tr>
             </tbody>
             <tbody>
-              <% @benefits[category].each do |benefit| %>
+              <% @grouped_benefits[category].each do |benefit| %>
                 <tr data-target="comparison-product.benefitRow" id=<%= benefit.id %>>
                   <td class="table--sticky-col table--fixed-col-width"><%= benefit.name.titleize %></td>
                 </tr>
@@ -74,7 +74,7 @@
     </div>
     <div class="column is-2 has-text-centered">
       <h3 class="subtitle is-3">Export</h3>
-      <button class="button is-large">
+      <button class="button is-large" data-action="click->comparison-export#excelExport">
         <span class="icon is-medium"><i class="fas fa-file-excel"></i></span>
       </button>
     </div>

--- a/app/views/comparisons/show.xlsx.axlsx
+++ b/app/views/comparisons/show.xlsx.axlsx
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+wb = xlsx_package.workbook
+
+category_start = 5
+category_end = nil
+category_positions = []
+
+# styles
+center_text = { alignment: { horizontal: :center, vertical: :center } }
+
+# cell styles indicating cell coverage
+paid_in_full_style = wb.styles.add_style(bg_color: '7dcea0')
+capped_benefit_style = wb.styles.add_style(bg_color: 'f0b27a')
+not_covered_style = wb.styles.add_style(bg_color: 'ec7063')
+
+# cell styles for benefit categories
+inpatient = wb.styles.add_style(bg_color: 'b7ede6')
+outpatient = wb.styles.add_style(bg_color: 'b7d7ed')
+therapists = wb.styles.add_style(bg_color: 'b7bced')
+medicines_and_appliances = wb.styles.add_style(bg_color: 'd3da6a')
+wellness = wb.styles.add_style(bg_color: 'daa76a')
+evacuation_and_repatriation = wb.styles.add_style(bg_color: 'e29bd1')
+maternity = wb.styles.add_style(bg_color: 'a2b6a9')
+dental = wb.styles.add_style(bg_color: 'c9e1fa')
+optical = wb.styles.add_style(bg_color: 'fae7c9')
+additional = wb.styles.add_style(bg_color: 'cac9fa')
+
+benefit_coverage_styles = {
+  'paid in full' => paid_in_full_style,
+  'capped benefit' => capped_benefit_style,
+  'not covered' => not_covered_style
+}
+
+benefit_category_styles = {
+  'inpatient' => inpatient,
+  'outpatient' => outpatient,
+  'therapists' => therapists,
+  'medicines and appliances' => medicines_and_appliances,
+  'wellness' => wellness,
+  'evacuation and repatriation' => evacuation_and_repatriation,
+  'maternity' => maternity,
+  'dental' => dental,
+  'optical' => optical,
+  'additional' => additional
+}
+
+wb.add_worksheet(name: 'Comparison') do |sheet|
+  # headers
+  sheet.add_row [nil, nil, *@comparison_products.map { |product| product.insurer.name }]
+  sheet.add_row [nil, nil, *@comparison_products.map { |product| product.product.name }]
+  sheet.add_row [nil, nil, *@comparison_products.map(&:product_module_names)]
+  sheet.add_row [nil, nil, *@comparison_products.map(&:overall_sum_assured)]
+
+  # benefits
+  category_starting_row = category_start
+
+  @benefit_categories.each do |category|
+    category_length = @grouped_benefits[category].length
+    @grouped_benefits[category].each do |benefit|
+      category_colour = benefit_category_styles[category]
+      row_styles = [category_colour, category_colour]
+      selected_product_benefits = @comparison_products.map do |product|
+        matched_benefit = product.module_benefits
+                                 .find { _1.benefit_id == benefit.id } || NullProductModuleBenefit.new
+        row_styles << benefit_coverage_styles[matched_benefit.benefit_status]
+        matched_benefit.explanation_of_benefit
+      end
+      sheet.add_row [category.titleize, benefit.name.titleize, *selected_product_benefits], style: row_styles
+    end
+
+    # merge category cells
+    next_category_start = category_starting_row + category_length
+    category_end = next_category_start - 1
+    category_cells = "A#{category_starting_row}:A#{category_end}"
+    category_positions << [category_starting_row, category_end]
+    sheet.merge_cells(category_cells)
+    category_starting_row = next_category_start
+  end
+
+  # columns widths
+  number_of_selected_products = @comparison_products.length
+  product_column_widths = Array.new(number_of_selected_products) { 40 }
+  sheet.column_widths 25, 25, *product_column_widths
+
+  # apply styles
+  last_col = Axlsx.col_ref(sheet.cols.size - 1)
+  sheet.add_style "A1:#{last_col}#{category_end}", center_text
+  sheet.add_style "A#{category_start}:#{last_col}#{category_end}", center_text, border: { style: :thin, color: '000000' }
+  sheet.add_style "C1:#{last_col}4", border: { style: :thin, color: '000000', edges: %i[left right] }, b: true
+end

--- a/app/views/comparisons/show.xlsx.axlsx
+++ b/app/views/comparisons/show.xlsx.axlsx
@@ -7,42 +7,25 @@ category_end = nil
 category_positions = []
 
 # styles
-center_text = { alignment: { horizontal: :center, vertical: :center } }
-
-# cell styles indicating cell coverage
-paid_in_full_style = wb.styles.add_style(bg_color: '7dcea0')
-capped_benefit_style = wb.styles.add_style(bg_color: 'f0b27a')
-not_covered_style = wb.styles.add_style(bg_color: 'ec7063')
-
-# cell styles for benefit categories
-inpatient = wb.styles.add_style(bg_color: 'b7ede6')
-outpatient = wb.styles.add_style(bg_color: 'b7d7ed')
-therapists = wb.styles.add_style(bg_color: 'b7bced')
-medicines_and_appliances = wb.styles.add_style(bg_color: 'd3da6a')
-wellness = wb.styles.add_style(bg_color: 'daa76a')
-evacuation_and_repatriation = wb.styles.add_style(bg_color: 'e29bd1')
-maternity = wb.styles.add_style(bg_color: 'a2b6a9')
-dental = wb.styles.add_style(bg_color: 'c9e1fa')
-optical = wb.styles.add_style(bg_color: 'fae7c9')
-additional = wb.styles.add_style(bg_color: 'cac9fa')
+center_text = { alignment: { horizontal: :center, vertical: :center, wrap_text: true } }
 
 benefit_coverage_styles = {
-  'paid in full' => paid_in_full_style,
-  'capped benefit' => capped_benefit_style,
-  'not covered' => not_covered_style
+  'paid in full' => wb.styles.add_style(bg_color: '7dcea0'),
+  'capped benefit' => wb.styles.add_style(bg_color: 'f0b27a'),
+  'not covered' => wb.styles.add_style(bg_color: 'ec7063')
 }
 
 benefit_category_styles = {
-  'inpatient' => inpatient,
-  'outpatient' => outpatient,
-  'therapists' => therapists,
-  'medicines and appliances' => medicines_and_appliances,
-  'wellness' => wellness,
-  'evacuation and repatriation' => evacuation_and_repatriation,
-  'maternity' => maternity,
-  'dental' => dental,
-  'optical' => optical,
-  'additional' => additional
+  'inpatient' => wb.styles.add_style(bg_color: 'b7ede6'),
+  'outpatient' => wb.styles.add_style(bg_color: 'b7d7ed'),
+  'therapists' => wb.styles.add_style(bg_color: 'b7bced'),
+  'medicines and appliances' => wb.styles.add_style(bg_color: 'd3da6a'),
+  'wellness' => wb.styles.add_style(bg_color: 'daa76a'),
+  'evacuation and repatriation' => wb.styles.add_style(bg_color: 'e29bd1'),
+  'maternity' => wb.styles.add_style(bg_color: 'a2b6a9'),
+  'dental' => wb.styles.add_style(bg_color: 'c9e1fa'),
+  'optical' => wb.styles.add_style(bg_color: 'fae7c9'),
+  'additional' => wb.styles.add_style(bg_color: 'cac9fa')
 }
 
 wb.add_worksheet(name: 'Comparison') do |sheet|
@@ -64,7 +47,8 @@ wb.add_worksheet(name: 'Comparison') do |sheet|
         matched_benefit = product.module_benefits
                                  .find { _1.benefit_id == benefit.id } || NullProductModuleBenefit.new
         row_styles << benefit_coverage_styles[matched_benefit.benefit_status]
-        matched_benefit.explanation_of_benefit
+
+        matched_benefit.full_benefit_coverage
       end
       sheet.add_row [category.titleize, benefit.name.titleize, *selected_product_benefits], style: row_styles
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { invitations: 'users/invitations' }
 
+  get '/comparisons/show', to: 'comparisons#show'
+
   resources :comparisons, only: %i[new]
   resources :comparison_products, only: %i[new create]
 

--- a/spec/models/product_module_benefit_spec.rb
+++ b/spec/models/product_module_benefit_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe ProductModuleBenefit, type: :model do
   it { expect(product_module_benefit).to validate_presence_of :benefit_limit }
   it { expect(product_module_benefit).to validate_uniqueness_of(:product_module_id).scoped_to(:benefit_id) }
   it { expect(product_module_benefit).to define_enum_for(:benefit_status).with_values(['paid in full', 'capped benefit']) }
+
+  describe('#full_benefit_coverage') do
+    subject(:product_module_benefit) do
+      create(:product_module_benefit, benefit_limit: 'paid in full', explanation_of_benefit: 'standard single room')
+    end
+
+    it('returns the benefit limit and explanation of benefit seperated by newlines') do
+      expect(product_module_benefit.full_benefit_coverage).to eq "paid in full\n\nstandard single room"
+    end
+  end
 end

--- a/spec/nulls/null_product_module_benefit_spec.rb
+++ b/spec/nulls/null_product_module_benefit_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe NullProductModuleBenefit do
+  subject(:null_product_module_benefit) { described_class.new }
+
+  describe('#icon') do
+    it 'returns the HTML for the fontawesome red cross' do
+      expect(null_product_module_benefit.icon).to eq "<span class='icon'><i class='fa fa-times red-cross'></i></span>"
+    end
+  end
+
+  describe('#benefit_limit') do
+    it 'returns Not covered' do
+      expect(null_product_module_benefit.benefit_limit).to eq 'Not covered'
+    end
+  end
+
+  describe('#explanation_of_benefit') do
+    it 'returns Not Covered' do
+      expect(null_product_module_benefit.explanation_of_benefit).to eq 'Not Covered'
+    end
+  end
+
+  describe 'benefit_status' do
+    it 'returns not covered' do
+      expect(null_product_module_benefit.benefit_status).to eq 'not covered'
+    end
+  end
+end

--- a/spec/nulls/null_product_module_benefit_spec.rb
+++ b/spec/nulls/null_product_module_benefit_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 RSpec.describe NullProductModuleBenefit do
   subject(:null_product_module_benefit) { described_class.new }
 
-  describe('#icon') do
+  describe '#icon' do
     it 'returns the HTML for the fontawesome red cross' do
       expect(null_product_module_benefit.icon).to eq "<span class='icon'><i class='fa fa-times red-cross'></i></span>"
     end
   end
 
-  describe('#benefit_limit') do
+  describe '#benefit_limit' do
     it 'returns Not covered' do
       expect(null_product_module_benefit.benefit_limit).to eq 'Not covered'
     end
   end
 
-  describe('#explanation_of_benefit') do
+  describe '#explanation_of_benefit' do
     it 'returns Not Covered' do
       expect(null_product_module_benefit.explanation_of_benefit).to eq 'Not Covered'
     end
@@ -24,6 +24,12 @@ RSpec.describe NullProductModuleBenefit do
   describe 'benefit_status' do
     it 'returns not covered' do
       expect(null_product_module_benefit.benefit_status).to eq 'not covered'
+    end
+  end
+
+  describe 'full_benefit_coverage' do
+    it 'returns the explanation_of_benefit' do
+      expect(null_product_module_benefit.full_benefit_coverage).to eq 'Not Covered'
     end
   end
 end

--- a/spec/services/comparison_product_spec.rb
+++ b/spec/services/comparison_product_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe ComparisonProduct do
+  subject(:comparison_product) { described_class.new(insurer, product, product_modules) }
+
+  let(:insurer) { create(:insurer, name: 'BUPA Global') }
+  let(:product) { create(:product, name: 'Lifeline', insurer: insurer) }
+  let(:product_modules) { [create(:product_module, name: 'Gold', product: product)] }
+
+  describe('#product_module_names') do
+    context('with one product module') do
+      it('returns the name of the product module') do
+        expect(comparison_product.product_module_names).to eq 'Gold'
+      end
+    end
+
+    context('with more than one product module') do
+      let(:product_modules) do
+        [
+          create(:product_module, name: 'Gold', product: product),
+          create(:product_module, name: 'Silver', product: product)
+        ]
+      end
+
+      it('returns the name of the product modules joined with a +') do
+        expect(comparison_product.product_module_names).to eq 'Gold + Silver'
+      end
+    end
+  end
+
+  describe('#overall_sum_assured') do
+    let(:product_modules) do
+      [
+        create(:product_module, name: 'Gold', product: product),
+        create(:product_module, name: 'Silver',
+                                category: 'outpatient',
+                                sum_assured: 'USD 2,000,000 | EUR 2,200,000 | GBP 1,500,000',
+                                product: product)
+      ]
+    end
+
+    it('returns the sum assured of the core module selected') do
+      expect(comparison_product.overall_sum_assured).to eq 'USD 3,000,000 | EUR 3,200,000 | GBP 2,500,000'
+    end
+  end
+
+  describe('#module_benefits') do
+    let(:product_modules) do
+      [
+        create(:product_module, name: 'Gold', product: product) do |product_module|
+          create(:product_module_benefit, product_module: product_module)
+        end,
+        create(:product_module, name: 'Silver', product: product) do |product_module|
+          create(:product_module_benefit, benefit_status: 'capped benefit', explanation_of_benefit: 'Paid in full for 30 days',
+                                          product_module: product_module)
+        end
+      ]
+    end
+    let(:module_benefits) do
+      a_collection_including(
+        an_object_having_attributes(benefit_status: 'paid in full',
+                                    benefit_limit: 'USD 1,000,000 | EUR 1,000,000 | GBP 850,000',
+                                    explanation_of_benefit: 'Within overall limit'),
+        an_object_having_attributes(benefit_status: 'capped benefit',
+                                    benefit_limit: 'USD 1,000,000 | EUR 1,000,000 | GBP 850,000',
+                                    explanation_of_benefit: 'Paid in full for 30 days')
+      )
+    end
+
+    it('returns all the product modules benefits of the selected product modules in one array') do
+      expect(comparison_product.module_benefits).to match(module_benefits)
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,10 +2723,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.523:
-  version "1.3.563"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.563.tgz#9da4e4f0d76c4b221784cc9ca81a8464e8180408"
-  integrity sha512-JkEjRFmuSegdTBCPG+RS1zw9csObHoN4el+X9EfEALO0UT7us8swxspJx7cRsrMkjd8bmmRTAd0xuUhvvb5DLg==
+electron-to-chromium@^1.3.562:
+  version "1.3.564"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.564.tgz#e9c319ae437b3eb8bbf3e3bae4bead5a21945961"
+  integrity sha512-fNaYN3EtKQWLQsrKXui8mzcryJXuA0LbCLoizeX6oayG2emBaS5MauKjCPAvc29NEY4FpLHIUWiP+Y0Bfrs5dg==
 
 elliptic@^6.5.3:
   version "6.5.3"


### PR DESCRIPTION
Add excel export option on comparison table

Exports the selected products in the comparison table to a spreadsheet. Because the table is dynamically generated the selected product info is placed into a hidden row in the table above each column. When the excel export button is clicked a stimulus controller intercepts the button click and gets the information from the hidden table row. It then formats the parameters and sends them through to the comparison show action where the spreadsheet is generated

A comparison product service object was created to hold the data for each table selection to be outputted into the spreadsheet and a nullproductmodulebenefit is used for when a benefit doesn't exist in the selected product and the display needs to output that it isn't covered.