### PR TITLE
Fix: Remove currency validation on product module model

### DIFF
--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -1,21 +1,13 @@
 class ProductModule < ApplicationRecord
   enum category: { 'core' => 0, 'outpatient' => 1, 'medicines and appliances' => 2, 'wellness' => 3,
                    'maternity' => 4, 'dental and optical' => 5, 'evacuation and repatriation' => 6 }
-  VALID_CURRENCY = /
-                    \A(eur|gbp|usd)\s?\d+,?\d*,?\d*\s?\|?\s?
-                    (eur|gbp|usd)\s?\d+,?\d*,?\d*\s?\|?\s?
-                    (eur|gbp|usd)\s?\d+,?\d*,?\d*\z
-                   /ix.freeze
 
   belongs_to :product
   has_many :product_module_benefits, dependent: :destroy, inverse_of: :product_module
 
   validates :name, presence: true, uniqueness: { scope: :category, case_sensitive: false }
   validates :category, presence: true
-  validates :sum_assured,
-            presence: true,
-            format: { with: VALID_CURRENCY,
-                      message: 'Please write the sum assured in the format "USD X,XXX,XXX | GBP X,XXX,XXX | EUR X,XXX,XXX"' }
+  validates :sum_assured, presence: true
 
   accepts_nested_attributes_for :product_module_benefits
 end

--- a/spec/models/product_module_spec.rb
+++ b/spec/models/product_module_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe ProductModule, type: :model do
   it { expect(product_module).to validate_uniqueness_of(:name).case_insensitive.scoped_to(:category) }
   it { expect(product_module).to validate_presence_of :category }
   it { expect(product_module).to validate_presence_of :sum_assured }
-  it { expect(product_module).to allow_value('USD 5,00 | GBP 6,00 | EUR 7,00').for(:sum_assured) }
-  it { expect(product_module).not_to allow_value('USD 5,00 | GBP 6,00 | EUR 7,00 | TNT 5,00').for(:sum_assured) }
 
   it do
     expect(product_module).to define_enum_for(:category)


### PR DESCRIPTION
Because: A product module doesn't have to have an overall sum assured

This commit: Removes the validation on the format of the sum assured for
a product module.