### PR TITLE
Fix: Change default excel output for benefits to benefit_limit

### DIFF
--- a/app/views/comparisons/show.xlsx.axlsx
+++ b/app/views/comparisons/show.xlsx.axlsx
@@ -48,7 +48,7 @@ wb.add_worksheet(name: 'Comparison') do |sheet|
                                  .find { _1.benefit_id == benefit.id } || NullProductModuleBenefit.new
         row_styles << benefit_coverage_styles[matched_benefit.benefit_status]
 
-        matched_benefit.full_benefit_coverage
+        matched_benefit.benefit_limit
       end
       sheet.add_row [category.titleize, benefit.name.titleize, *selected_product_benefits], style: row_styles
     end


### PR DESCRIPTION
Because: The explanation of benefits are quite long

This commit: Changes the default full_benefit_coverage that used to be
the default in excel output to just the benefit limit

Previously the full benefit limit was too long and made comparison
benefits on an excel sheet difficult. Using just the benefit limit keeps
it compact and easier to compare