### PR TITLE
Benefit weight

### DIFF
--- a/app/controllers/comparison_products_controller.rb
+++ b/app/controllers/comparison_products_controller.rb
@@ -5,5 +5,6 @@ class ComparisonProductsController < ApplicationController
     @product_modules = ProductModule
                        .includes(product_module_benefits: :benefit)
                        .where(id: params[:comparison_product][:product_modules])
+    @comparison_product = ComparisonProduct.new(@insurer, @product, @product_modules)
   end
 end

--- a/app/javascript/controllers/comparison_product_controller.js
+++ b/app/javascript/controllers/comparison_product_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
   }
 
   addSelectedProductToComparison(data) {
-    this.comparisonProduct = new ComparisonProduct(data['insurer'], data['product'], data['product_modules'])
+    this.comparisonProduct = new ComparisonProduct(data['insurer'], data['product'], data['product_modules'], data['module_benefits'])
     this.addSelectedProductDetails()
     this.addInsurer()
     this.addProduct()

--- a/app/javascript/services/comparison_product.js
+++ b/app/javascript/services/comparison_product.js
@@ -1,9 +1,9 @@
 class ComparisonProduct {
-  constructor(insurer, product, productModules) {
+  constructor(insurer, product, productModules, moduleBenefits) {
     this._insurer = insurer
     this._product = product
     this._productModules = productModules
-    this._productModuleBenefits = this.productModuleBenefits()
+    this._moduleBenefits = moduleBenefits
     this._benefitIcons = {
       "paid in full": "<span class='icon'><i class='fa fa-check icon--full-cover'></i></span>",
       "capped benefit": "<span class='icon'><i class='fa fa-circle-notch icon--capped-cover'></i></span>",
@@ -31,15 +31,10 @@ class ComparisonProduct {
   }
 
   productModuleBenefit(id) {
-    const productModuleBenefit = this._productModuleBenefits.find(productModule => productModule.benefit.id == id)
+    const productModuleBenefit = this._moduleBenefits.find(productModule => productModule.benefit.id == id)
     if(!productModuleBenefit) return undefined
     productModuleBenefit.benefit_icon = this.benefitIcon(productModuleBenefit.benefit_status)
     return productModuleBenefit
-  }
-
-  productModuleBenefits() {
-    const moduleBenefits = this._productModules.map(productModule => productModule.product_module_benefits)
-    return [].concat.apply([], moduleBenefits)
   }
 
   benefitIcon(benefit_status) {

--- a/app/services/comparison_product.rb
+++ b/app/services/comparison_product.rb
@@ -1,10 +1,11 @@
 class ComparisonProduct
-  attr_reader :insurer, :product, :product_modules
+  attr_reader :insurer, :product, :product_modules, :all_selected_benefits
 
   def initialize(insurer, product, product_modules)
     @insurer = insurer
     @product = product
     @product_modules = product_modules
+    @all_selected_benefits = selected_benefits
   end
 
   def product_module_names
@@ -17,6 +18,20 @@ class ComparisonProduct
   end
 
   def module_benefits
+    @module_benefits ||= all_selected_benefits.keep_if { benefit_with_maximum_weight(_1) == _1 }
+  end
+
+  private
+
+  def selected_benefits
     product_modules.map(&:product_module_benefits).flatten
+  end
+
+  def benefit_with_maximum_weight(module_benefit)
+    matched_benefits(module_benefit).max_by(&:benefit_weighting)
+  end
+
+  def matched_benefits(module_benefit)
+    all_selected_benefits.find_all { _1.benefit.name == module_benefit.benefit.name }
   end
 end

--- a/app/views/comparison_products/create.json.jbuilder
+++ b/app/views/comparison_products/create.json.jbuilder
@@ -1,15 +1,15 @@
 json.insurer do
-  json.name @insurer.name
+  json.name @comparison_product.insurer.name
 end
 json.product do
-  json.name @product.name
+  json.name @comparison_product.product.name
 end
-json.product_modules @product_modules do |product_module|
+json.product_modules @comparison_product.product_modules do |product_module|
   json.(product_module, :name, :category, :sum_assured)
-  json.product_module_benefits product_module.product_module_benefits do |product_module_benefit|
-    json.(product_module_benefit, :benefit_status, :benefit_limit, :explanation_of_benefit)
-    json.benefit do
-      json.(product_module_benefit.benefit, :id, :name, :category)
-    end
+end
+json.module_benefits @comparison_product.module_benefits do |product_module_benefit|
+  json.(product_module_benefit, :benefit_status, :benefit_limit, :explanation_of_benefit)
+  json.benefit do
+    json.(product_module_benefit.benefit, :id, :name, :category)
   end
 end

--- a/db/migrate/20201007210237_add_benefit_weighting_to_product_module_benefit.rb
+++ b/db/migrate/20201007210237_add_benefit_weighting_to_product_module_benefit.rb
@@ -1,0 +1,5 @@
+class AddBenefitWeightingToProductModuleBenefit < ActiveRecord::Migration[6.0]
+  def change
+    add_column :product_module_benefits, :benefit_weighting, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_28_201939) do
+ActiveRecord::Schema.define(version: 2020_10_07_210237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2020_09_28_201939) do
     t.text "explanation_of_benefit"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "benefit_weighting", default: 0
     t.index ["benefit_id"], name: "index_product_module_benefits_on_benefit_id"
     t.index ["product_module_id", "benefit_id"], name: "index_product_module_benefits_on_product_module_and_benefit", unique: true
     t.index ["product_module_id"], name: "index_product_module_benefits_on_product_module_id"

--- a/spec/factories/product_module_benefits.rb
+++ b/spec/factories/product_module_benefits.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     benefit_status { 'paid in full' }
     benefit_limit { 'USD 1,000,000 | EUR 1,000,000 | GBP 850,000' }
     explanation_of_benefit { 'Within overall limit' }
+    benefit_weighting { 0 }
   end
 end

--- a/spec/services/comparison_product_spec.rb
+++ b/spec/services/comparison_product_spec.rb
@@ -70,5 +70,42 @@ RSpec.describe ComparisonProduct do
     it('returns all the product modules benefits of the selected product modules in one array') do
       expect(comparison_product.module_benefits).to match(module_benefits)
     end
+
+    context('when multiple module benefits have the same benefit association') do
+      let(:benefit) { create(:benefit, name: 'accomodation', category: 'inpatient') }
+      let(:product_modules) do
+        [
+          create(:product_module, name: 'Gold', product: product) do |product_module|
+            create(:product_module_benefit, benefit_status: 'paid in full',
+                                            explanation_of_benefit: 'Paid in full',
+                                            product_module: product_module,
+                                            benefit_weighting: 0,
+                                            benefit: benefit)
+          end,
+          create(:product_module, name: 'Silver', product: product) do |product_module|
+            create(:product_module_benefit, benefit_status: 'capped benefit',
+                                            explanation_of_benefit: 'Paid in full for 30 days',
+                                            product_module: product_module,
+                                            benefit_weighting: 1,
+                                            benefit: benefit)
+          end
+        ]
+      end
+
+      it 'keeps the module benefit with the higher weighting' do
+        expect(comparison_product.module_benefits).to include(
+          an_object_having_attributes(benefit_status: 'capped benefit',
+                                      benefit_limit: 'USD 1,000,000 | EUR 1,000,000 | GBP 850,000',
+                                      explanation_of_benefit: 'Paid in full for 30 days')
+        )
+      end
+
+      it 'removes the module benefit with the lower weighting' do
+        expect(comparison_product.module_benefits).not_to include(
+          an_object_having_attributes(benefit_status: 'paid in full',
+                                      explanation_of_benefit: 'Paid in full')
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds a benefit weight to the product_module_benefit table

Because under a product, the product module benefits can point to duplicate benefits as later product_module_benefits enhance cover this PR adds a weighting column to the product_module_benefits table. This allows a ComparisonProduct to select the benefit with the highest weighting