### PR TITLE
Check core module is selected on comparison page before enabling submit

### DIFF
--- a/app/javascript/controllers/health_comparison_product_select_controller.js
+++ b/app/javascript/controllers/health_comparison_product_select_controller.js
@@ -90,7 +90,7 @@ export default class extends Controller {
           ${productModules.map(module => {
             return `
               <label class="radio">
-                <input type="radio" name="comparison_product[product_modules][${module.category}]" value="${module.id}" data-action="change->health-comparison-product-select#enableSubmitButton">
+                <input class="${category}" type="radio" name="comparison_product[product_modules][${module.category}]" value="${module.id}" data-action="change->health-comparison-product-select#submitButtonCheck">
                 ${module.name}
               </label>
             `
@@ -98,6 +98,22 @@ export default class extends Controller {
         </div>
       </div>
     `
+  }
+
+  submitButtonCheck(event) {
+    if(this.submitButtonEnabled()) return;
+    
+    this.enableSubmitIfCoreModuleSelected(event.target)
+  }
+
+  submitButtonEnabled() {
+    this.comparisonProductSubmitTarget.disabled === false
+  }
+
+  enableSubmitIfCoreModuleSelected(module) {
+    if(module.classList.contains('core')) {
+      this.enableSubmitButton()
+    }
   }
 
   enableSubmitButton() {


### PR DESCRIPTION
Because: A core module must be selected for the comparison table

This commit: Blocks enabled the submit button unless a core module is
selected

If the submit button is already enabled it will simply return to stop it
disabling the submit button when selecting a non core module after a
core module is selected