### PR TITLE
Update Ruby version in github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Ruby
         uses: actions/setup-ruby@v1.1.2
         with:
-          ruby-version: 2.7.1
+          ruby-version: 2.7
 
       - uses: actions/checkout@v2.3.4
 


### PR DESCRIPTION
Because: CI was failing as Rubocop was still using version 2.7.1

This commit: Updates the version used to 2.7.2