### PR TITLE
Ensure factories produce unique names for attributes with a uniqueness

### DIFF
--- a/spec/factories/benefits.rb
+++ b/spec/factories/benefits.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :benefit do
-    name { Faker::Commerce.product_name }
+    name { Faker::Commerce.unique.product_name }
     category { 'inpatient' }
   end
 end

--- a/spec/factories/insurers.rb
+++ b/spec/factories/insurers.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :insurer do
-    name { Faker::Company.name }
+    name { Faker::Company.unique.name }
   end
 
   trait :with_individual_product do

--- a/spec/factories/product_modules.rb
+++ b/spec/factories/product_modules.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :product_module do
-    name { Faker::Commerce.product_name }
+    name { Faker::Commerce.unique.product_name }
     category { 'core' }
     sum_assured { 'USD 3,000,000 | EUR 3,200,000 | GBP 2,500,000' }
     product

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :product do
-    name { Faker::Company.name }
+    name { Faker::Company.unique.name }
     customer_type { 'individual' }
     insurer
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.email }
-    password { Faker::Internet.password }
+    email { Faker::Internet.unique.email }
+    password { Faker::Internet.unique.password }
     admin { false }
 
     factory :admin_user do


### PR DESCRIPTION
validation

Because: Some models have uniqueness validations

This commit: Ensures Faker produces unique values for those attributes