### PR TITLE
Fix: Scope product module name to both category and product_id

### DIFF
--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -5,7 +5,7 @@ class ProductModule < ApplicationRecord
   belongs_to :product
   has_many :product_module_benefits, dependent: :destroy, inverse_of: :product_module
 
-  validates :name, presence: true, uniqueness: { scope: :category, case_sensitive: false }
+  validates :name, presence: true, uniqueness: { scope: %i[category product_id], case_sensitive: false }
   validates :category, presence: true
   validates :sum_assured, presence: true
 

--- a/db/migrate/20201211223759_add_index_to_product_modules.rb
+++ b/db/migrate/20201211223759_add_index_to_product_modules.rb
@@ -1,0 +1,6 @@
+class AddIndexToProductModules < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :product_modules, %i[name category]
+    add_index :product_modules, %i[name category product_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_210237) do
+ActiveRecord::Schema.define(version: 2020_12_11_223759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2020_10_07_210237) do
     t.bigint "product_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["name", "category"], name: "index_product_modules_on_name_and_category", unique: true
+    t.index ["name", "category", "product_id"], name: "index_product_modules_on_name_and_category_and_product_id", unique: true
     t.index ["product_id"], name: "index_product_modules_on_product_id"
   end
 

--- a/spec/models/product_module_spec.rb
+++ b/spec/models/product_module_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProductModule, type: :model do
   before { create(:product_module) }
 
   it { expect(product_module).to validate_presence_of :name }
-  it { expect(product_module).to validate_uniqueness_of(:name).case_insensitive.scoped_to(:category) }
+  it { expect(product_module).to validate_uniqueness_of(:name).case_insensitive.scoped_to(%i[category product_id]) }
   it { expect(product_module).to validate_presence_of :category }
   it { expect(product_module).to validate_presence_of :sum_assured }
 


### PR DESCRIPTION
Because: A user should be able to create two product modules with the
same name belonging to different products

This commit: Fixes the validation so that it is scoped to both category
and product_id