### PR TITLE
Fix: Update categories in comparison select stimulus controller

### DIFF
--- a/app/javascript/controllers/health_comparison_product_select_controller.js
+++ b/app/javascript/controllers/health_comparison_product_select_controller.js
@@ -57,7 +57,7 @@ export default class extends Controller {
   }
 
   productModuleCategories() {
-    return ['core', 'outpatient', 'medicines and appliances', 'wellness', 'maternity', 'dental and optical', 'evacuation and repatriation']
+    return ['core', 'outpatient', 'medicines_and_appliances', 'wellness', 'maternity', 'dental_and_optical', 'evacuation_and_repatriation']
   }
 
   groupProductModules(productModules) {
@@ -77,7 +77,7 @@ export default class extends Controller {
 
   titleize(phrase) {
     return phrase
-      .split(' ')
+      .split('_')
       .map(word => word[0].toUpperCase() + word.slice(1, word.length))
       .join(' ')
   }


### PR DESCRIPTION
Because: The categories didn't match the categories for product modules
on the server side which meant some product modules under that category
weren't being displayed

This commit: Updates the categories to match so all product modules are
shown in the comparison select sidebar