### PR TITLE
Add LinkedProductModule model

### DIFF
--- a/app/javascript/controllers/comparison_controller.js
+++ b/app/javascript/controllers/comparison_controller.js
@@ -23,6 +23,21 @@ export default class extends ApplicationController {
     );
   }
 
+  loadCoreProductModules() {
+    this.stimulate("Comparison#core_modules", this.productTarget.value);
+  }
+
+  loadElectiveProductModules(event) {
+    if (event.target.dataset.category !== "core") return;
+
+    const productModuleId = event.target.value;
+    this.stimulate(
+      "Comparison#elective_modules",
+      productModuleId,
+      this.productTarget.value
+    );
+  }
+
   loadProductModules() {
     this.stimulate("Comparison#product_modules", this.productTarget.value);
   }

--- a/app/models/linked_product_module.rb
+++ b/app/models/linked_product_module.rb
@@ -1,0 +1,4 @@
+class LinkedProductModule < ApplicationRecord
+  belongs_to :product_module
+  belongs_to :linked_module, class_name: 'ProductModule', inverse_of: :linked_product_modules
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,4 +6,8 @@ class Product < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :insurer, presence: true
+
+  def core_modules
+    product_modules.where(product_modules: { category: 'core' })
+  end
 end

--- a/app/models/product_module.rb
+++ b/app/models/product_module.rb
@@ -4,6 +4,8 @@ class ProductModule < ApplicationRecord
 
   belongs_to :product
   has_many :product_module_benefits, dependent: :destroy, inverse_of: :product_module
+  has_many :linked_product_modules, dependent: :destroy, inverse_of: :linked_module
+  has_many :linked_modules, through: :linked_product_modules
 
   validates :name, presence: true, uniqueness: { scope: %i[category product_id], case_sensitive: false }
   validates :category, presence: true

--- a/app/reflexes/comparison_reflex.rb
+++ b/app/reflexes/comparison_reflex.rb
@@ -3,15 +3,31 @@
 class ComparisonReflex < ApplicationReflex
   def products(insurer_id, customer_type)
     @products = Insurer.find(insurer_id).products.where(customer_type: customer_type)
+
     morph '#product-select-wrapper', render(partial: 'selection_form_products', locals: { products: @products })
   end
 
-  def product_modules(product_id)
+  def core_modules(product_id)
     @product_module_categories = ProductModule.categories.keys
-    @product_modules = Product.find(product_id).product_modules
+    @product_modules = Product.find(product_id).core_modules
+
     morph '#product-modules', render(partial: 'selection_form_product_modules',
                                      locals: { product_module_categories: @product_module_categories,
-                                               product_modules: @product_modules })
+                                               product_modules: @product_modules,
+                                               core_module: nil })
+  end
+
+  def elective_modules(core_module_id, product_id)
+    @product_module_categories = ProductModule.categories.keys
+    @core_module = ProductModule.find(core_module_id)
+    @core_modules = Product.find(product_id).core_modules
+    @elective_modules = @core_module.linked_modules
+    @product_modules = [*@core_modules].concat([*@elective_modules])
+
+    morph '#product-modules', render(partial: 'selection_form_product_modules',
+                                     locals: { product_module_categories: @product_module_categories,
+                                               product_modules: @product_modules,
+                                               core_module: @core_module })
   end
 
   def selected_products(selection, options)

--- a/app/views/comparisons/_selection_form_product_modules.html.erb
+++ b/app/views/comparisons/_selection_form_product_modules.html.erb
@@ -2,9 +2,16 @@
   <div class="field">
     <h5 class="title is-5"><%= category.titleize %></h5>
     <div class="control">
-      <%= collection_radio_buttons :product_modules, "product_modules[#{category}]", product_modules.group_by(&:category)[category], :id, :name do |button| %>
+      <%= collection_radio_buttons :product_modules, category, product_modules.group_by(&:category)[category], :id, :name do |button| %>
         <label class="radio">
-          <%= button.radio_button(data: { comparison_target: 'productModule' }) %>
+          <%=
+            button.radio_button(
+              data: { category: category,
+                      comparison_target: 'productModule',
+                      action: 'change->comparison#loadElectiveProductModules' },
+              checked: button.value.to_s == core_module&.id.to_s ? true : false
+            )
+          %>
           <%= button.label %>
         </label>
       <% end %>

--- a/app/views/comparisons/_selection_form_products.html.erb
+++ b/app/views/comparisons/_selection_form_products.html.erb
@@ -2,7 +2,7 @@
   <%= select_tag "comparison_product[product]", options_from_collection_for_select(products, "id", "name"),
     include_blank: 'Select Product...',
     data: { comparison_target: 'product',
-            action: 'change->comparison#loadProductModules' },
+            action: 'change->comparison#loadCoreProductModules' },
     id: 'product-select'
   %>
 </div>

--- a/db/migrate/20210206214208_create_linked_product_modules.rb
+++ b/db/migrate/20210206214208_create_linked_product_modules.rb
@@ -1,0 +1,12 @@
+class CreateLinkedProductModules < ActiveRecord::Migration[6.1]
+  def change
+    create_table :linked_product_modules do |t|
+      t.references :product_module, null: false, foreign_key: true
+      t.references :linked_module, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :linked_product_modules, :product_modules, column: :linked_module_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_11_223759) do
+ActiveRecord::Schema.define(version: 2021_02_06_214208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,15 @@ ActiveRecord::Schema.define(version: 2020_12_11_223759) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["name"], name: "index_insurers_on_name", unique: true
+  end
+
+  create_table "linked_product_modules", force: :cascade do |t|
+    t.bigint "product_module_id", null: false
+    t.bigint "linked_module_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["linked_module_id"], name: "index_linked_product_modules_on_linked_module_id"
+    t.index ["product_module_id"], name: "index_linked_product_modules_on_product_module_id"
   end
 
   create_table "product_module_benefits", force: :cascade do |t|
@@ -90,6 +99,8 @@ ActiveRecord::Schema.define(version: 2020_12_11_223759) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "linked_product_modules", "product_modules"
+  add_foreign_key "linked_product_modules", "product_modules", column: "linked_module_id"
   add_foreign_key "product_module_benefits", "benefits"
   add_foreign_key "product_module_benefits", "product_modules"
   add_foreign_key "product_modules", "products"

--- a/spec/factories/linked_product_modules.rb
+++ b/spec/factories/linked_product_modules.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :linked_product_module do
+    product_module { nil }
+    linked_module { nil }
+  end
+end

--- a/spec/models/linked_product_module_spec.rb
+++ b/spec/models/linked_product_module_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LinkedProductModule, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/product_module_spec.rb
+++ b/spec/models/product_module_spec.rb
@@ -17,5 +17,7 @@ RSpec.describe ProductModule, type: :model do
   end
 
   it { expect(product_module).to have_many(:product_module_benefits).dependent(:destroy) }
+  it { expect(product_module).to have_many(:linked_product_modules).dependent(:destroy) }
+  it { expect(product_module).to have_many(:linked_modules).through(:linked_product_modules) }
   it { expect(product_module).to accept_nested_attributes_for(:product_module_benefits) }
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -11,4 +11,25 @@ RSpec.describe Product, type: :model do
   it { expect(product).to validate_presence_of :insurer }
   it { expect(product).to have_many(:product_modules).dependent(:destroy) }
   it { expect(product).to define_enum_for(:customer_type).with_values(%w[individual corporate]) }
+
+  describe('#core_modules') do
+    subject(:product)  do
+      create(:product) do |product|
+        create_list(:product_module, 3, product: product)
+        create_list(:product_module, 2, category: 'outpatient', product: product)
+      end
+    end
+
+    it('returns those product_modules with a core category that belong to the product') do
+      expect(
+        product.core_modules.all? { |product_module| product_module.category == 'core' }
+      ).to be true
+    end
+
+    it('does not select product_modules which do not have a core category') do
+      expect(
+        product.core_modules.none? { |product_module| product_module.category != 'core' }
+      ).to be true
+    end
+  end
 end

--- a/spec/system/add_corporate_health_insurance_product_to_comparison_table_spec.rb
+++ b/spec/system/add_corporate_health_insurance_product_to_comparison_table_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe 'Add a corporate plan to the comparison table', type: :system, js
           create_list(:product_module_benefit, 3, product_module: product_module)
           create_list(:product_module_benefit, 2, benefit_status: 'capped_benefit', product_module: product_module)
         end
+        create(:product_module, name: 'Evacuation',
+                                product: product,
+                                category: 'evacuation_and_repatriation') do |product_module|
+          create_list(:product_module_benefit, 2, product_module: product_module)
+          create(:linked_product_module, product_module: ProductModule.find_by(name: 'Gold'), linked_module: product_module)
+        end
       end
       create(:product, name: 'Company', insurer: insurer)
     end
@@ -30,11 +36,19 @@ RSpec.describe 'Add a corporate plan to the comparison table', type: :system, js
     find('#insurer-select')
     expect(page).not_to have_select('insurer-select', with_options: ['Allianz'])
 
+    select 'BUPA Global', from: 'insurer-select'
+
     expect(page).not_to have_select('product-select', with_options: ['Company'])
 
-    select 'BUPA Global', from: 'insurer-select'
     select 'Lifeline', from: 'product-select'
+
+    expect(page).to have_selector('h5', text: 'Core')
+    expect(page).not_to have_selector('h5', text: 'Evacuation And Repatriation')
+
     page.choose 'Gold'
+
+    expect(page).to have_selector('h5', text: 'Evacuation And Repatriation')
+
     click_button 'Load Benefits'
 
     expect(find('tr#insurer-name > td:nth-of-type(1)')).to have_content 'BUPA Global'
@@ -44,6 +58,6 @@ RSpec.describe 'Add a corporate plan to the comparison table', type: :system, js
       .to have_content 'USD 3,000,000 | EUR 3,200,000 | GBP 2,500,000'
     expect(page).to have_css('i.icon--full-cover', count: 3)
     expect(page).to have_css('i.icon--capped-cover', count: 2)
-    expect(page).to have_css('i.icon--not-covered', count: 5)
+    expect(page).to have_css('i.icon--not-covered', count: 7)
   end
 end

--- a/spec/system/add_individual_international_health_insurance_product_to_comparison_table_spec.rb
+++ b/spec/system/add_individual_international_health_insurance_product_to_comparison_table_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Add an individual plan to the comparison table', type: :system, 
                                 product: product,
                                 category: 'evacuation_and_repatriation') do |product_module|
           create_list(:product_module_benefit, 2, product_module: product_module)
+          create(:linked_product_module, product_module: ProductModule.find_by(name: 'Gold'), linked_module: product_module)
         end
       end
       create(:product, name: 'Company', customer_type: 'corporate', insurer: insurer)
@@ -35,13 +36,19 @@ RSpec.describe 'Add an individual plan to the comparison table', type: :system, 
     find('#insurer-select')
     expect(page).not_to have_select('insurer-select', with_options: ['Allianz'])
 
+    select 'BUPA Global', from: 'insurer-select'
+
     expect(page).not_to have_select('product-select', with_options: ['Company'])
 
-    select 'BUPA Global', from: 'insurer-select'
     select 'Lifeline', from: 'product-select'
+
     expect(page).to have_selector('h5', text: 'Core')
-    expect(page).to have_selector('h5', text: 'Evacuation And Repatriation')
+    expect(page).not_to have_selector('h5', text: 'Evacuation And Repatriation')
+
     page.choose 'Gold'
+
+    expect(page).to have_selector('h5', text: 'Evacuation And Repatriation')
+
     click_button 'Load Benefits'
 
     expect(find('tr#insurer-name > td:nth-of-type(1)')).to have_content 'BUPA Global'


### PR DESCRIPTION
Because: Only those product modules linked with the core product module
should be shown on the comparison product form for the product module
radio buttons

This commit: Introduces a LinkedProductModule model. The model linked to
the core product module and a linked_module which itself is another
product module. The idea is to link all "sub_modules" to a core module
so that when a core module is selected on the product module select, it
can then show only those linked product modules