### PR TITLE
Create Policy for a suitable health product

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,6 @@ RSpec/MultipleExpectations:
 RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/helpers/**/*.rb'
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/app/policies/suitable_health_product_policy.rb
+++ b/app/policies/suitable_health_product_policy.rb
@@ -1,0 +1,29 @@
+class SuitableHealthProductPolicy
+  def initialize(health_product, required_coverages)
+    @health_product = health_product
+    @required_coverages = required_coverages
+  end
+
+  def allowed?
+    required_coverages? &&
+      core_module_outpatient_cover_check_valid?
+  end
+
+  private
+
+  attr_reader :health_product, :required_coverages
+
+  def required_coverages?
+    health_product.coverage_areas?(required_coverages)
+  end
+
+  def core_module_outpatient_cover_check_valid?
+    return true if required_coverages.include? 'outpatient'
+
+    core_module.coverage_areas.none?(&:outpatient?)
+  end
+
+  def core_module
+    health_product.product_modules.find(&:core?)
+  end
+end

--- a/app/services/matched_coverage_comparison_products.rb
+++ b/app/services/matched_coverage_comparison_products.rb
@@ -20,7 +20,7 @@ class MatchedCoverageComparisonProducts
 
   def filtered_comparison_products
     comparison_products.filter_map do |comparison_product|
-      if includable_comparison_product?(comparison_product)
+      if SuitableHealthProductPolicy.new(comparison_product, required_coverages).allowed?
         ComparisonProduct.new(
           insurer: comparison_product.insurer,
           product: comparison_product.product,
@@ -28,17 +28,6 @@ class MatchedCoverageComparisonProducts
         )
       end
     end
-  end
-
-  def includable_comparison_product?(comparison_product)
-    comparison_product.coverage_areas?(required_coverages) && core_module_outpatient_check_valid?(comparison_product)
-  end
-
-  def core_module_outpatient_check_valid?(match)
-    return true if required_coverages.include? 'outpatient'
-
-    core_module = match.product_modules.find { _1.category == 'core' }
-    core_module.coverage_areas.none? { _1.category == 'outpatient' }
   end
 
   def product_modules_with_required_coverage_areas(product_modules)

--- a/spec/policies/suitable_health_product_policy_spec.rb
+++ b/spec/policies/suitable_health_product_policy_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe SuitableHealthProductPolicy do
+  let(:suitable_health_product_policy) { described_class.new(health_product, required_coverages).allowed? }
+  let(:health_product) do
+    ComparisonProduct.new(insurer: insurer, product: product, product_modules: product_modules)
+  end
+  let(:insurer) { create(:insurer) }
+  let(:product) { create(:product, insurer: insurer) }
+
+  describe('#allowed?') do
+    context 'when the health_product does not have the required coverage areas' do
+      let(:product_modules) { [core_module] }
+      let(:core_module) do
+        create(:product_module) do |product_module|
+          create(:coverage_area, category: 'inpatient', product_module: product_module)
+        end
+      end
+      let(:required_coverages) { %w[inpatient wellness] }
+
+      it 'returns false' do
+        expect(suitable_health_product_policy).to be false
+      end
+    end
+
+    context 'when the health product does have the required coverage areas' do
+      let(:product_modules) { [core_module] }
+      let(:core_module) do
+        create(:product_module) do |product_module|
+          create(:coverage_area, category: 'inpatient', product_module: product_module)
+          create(:coverage_area, category: 'wellness', product_module: product_module)
+        end
+      end
+      let(:required_coverages) { %w[inpatient wellness] }
+
+      it 'returns true' do
+        expect(suitable_health_product_policy).to be true
+      end
+    end
+
+    context 'when the health product has an outpatient coverage area' do
+      let(:product_modules) { [core_module] }
+      let(:core_module) do
+        create(:product_module) do |product_module|
+          create(:coverage_area, product_module: product_module)
+          create(:coverage_area, category: 'outpatient', product_module: product_module)
+        end
+      end
+      let(:required_coverages) { %w[inpatient outpatient] }
+
+      it 'returns true when the required coverages includes outpatient' do
+        expect(suitable_health_product_policy).to be true
+      end
+    end
+
+    context 'when the health product has no outpatient coverage area' do
+      let(:product_modules) { [core_module] }
+      let(:core_module) do
+        create(:product_module) do |product_module|
+          create(:coverage_area, product_module: product_module)
+        end
+      end
+      let(:required_coverages) { %w[inpatient outpatient] }
+
+      it 'returns false when the required coverages does not include outpatient' do
+        expect(suitable_health_product_policy).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because there are several criteria for whether a comparison product can
be included in a list of suitable products for a client

This commit
- Add suitable health product policy
- Refactor MatchedCoverageComparisonProducts to use SuitableHealthProductPolicy
- Exclude MemoziedHelper cop from spec files