### PR TITLE
Add applicant age check to health product matcher

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,6 +5,8 @@ class Product < ApplicationRecord
   has_many :product_modules, dependent: :destroy
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :minimum_applicant_age, presence: true
+  validates :maximum_applicant_age, presence: true
   validates :insurer, presence: true
 
   scope :individual_products, -> { where(customer_type: 'individual') }

--- a/app/policies/suitable_health_product_policy.rb
+++ b/app/policies/suitable_health_product_policy.rb
@@ -1,17 +1,21 @@
 class SuitableHealthProductPolicy
-  def initialize(health_product, required_coverages)
+  def initialize(health_product, required_coverages:, main_applicant_age:, dependants_ages:)
     @health_product = health_product
     @required_coverages = required_coverages
+    @main_applicant_age = main_applicant_age
+    @dependants_ages = dependants_ages
   end
 
   def allowed?
     required_coverages? &&
-      core_module_outpatient_cover_check_valid?
+      core_module_outpatient_cover_check_valid? &&
+      main_applicant_age_valid? &&
+      dependants_ages_valid?
   end
 
   private
 
-  attr_reader :health_product, :required_coverages
+  attr_reader :health_product, :required_coverages, :main_applicant_age, :dependants_ages
 
   def required_coverages?
     health_product.coverage_areas?(required_coverages)
@@ -21,6 +25,14 @@ class SuitableHealthProductPolicy
     return true if required_coverages.include? 'outpatient'
 
     core_module.coverage_areas.none?(&:outpatient?)
+  end
+
+  def main_applicant_age_valid?
+    main_applicant_age.between?(health_product.minimum_applicant_age, health_product.maximum_applicant_age)
+  end
+
+  def dependants_ages_valid?
+    dependants_ages.all? { _1 < health_product.maximum_applicant_age}
   end
 
   def core_module

--- a/app/services/comparison_product.rb
+++ b/app/services/comparison_product.rb
@@ -5,6 +5,8 @@ class ComparisonProduct
 
   delegate :name, prefix: 'insurer', to: :insurer
   delegate :name, prefix: 'product', to: :product
+  delegate :minimum_applicant_age, to: :product
+  delegate :maximum_applicant_age, to: :product
 
   def product_module_names
     product_modules.map(&:name).join(' + ')

--- a/app/services/matched_coverage_comparison_products.rb
+++ b/app/services/matched_coverage_comparison_products.rb
@@ -1,11 +1,12 @@
 class MatchedCoverageComparisonProducts
-  def self.match(required_coverages, comparison_products)
-    new(required_coverages, comparison_products).match
+  def self.match(comparison_products, **args)
+    new(comparison_products, **args).match
   end
 
-  def initialize(required_coverages, comparison_products)
-    @required_coverages = required_coverages
+  def initialize(comparison_products, **args)
     @comparison_products = comparison_products
+    @required_coverages = args[:required_coverages]
+    @args = args
   end
 
   def match
@@ -16,11 +17,11 @@ class MatchedCoverageComparisonProducts
 
   private
 
-  attr_reader :required_coverages, :comparison_products
+  attr_reader :required_coverages, :comparison_products, :args
 
   def filtered_comparison_products
     comparison_products.filter_map do |comparison_product|
-      if SuitableHealthProductPolicy.new(comparison_product, required_coverages).allowed?
+      if SuitableHealthProductPolicy.new(comparison_product, **args).allowed?
         ComparisonProduct.new(
           insurer: comparison_product.insurer,
           product: comparison_product.product,

--- a/db/migrate/20210806174318_add_minimum_and_maximum_age_to_products.rb
+++ b/db/migrate/20210806174318_add_minimum_and_maximum_age_to_products.rb
@@ -1,0 +1,15 @@
+class AddMinimumAndMaximumAgeToProducts < ActiveRecord::Migration[6.1]
+  def change
+    change_table :products, bulk: true do |t|
+      t.integer :minimum_applicant_age
+      t.integer :maximum_applicant_age
+    end
+
+    Product.find_each do |product|
+      product.update(minimum_applicant_age: 18, maximum_applicant_age: 80)
+    end
+
+    change_column_null :products, :minimum_applicant_age, false
+    change_column_null :products, :maximum_applicant_age, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_18_210748) do
+ActiveRecord::Schema.define(version: 2021_08_06_174318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,8 @@ ActiveRecord::Schema.define(version: 2021_04_18_210748) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "customer_type"
+    t.integer "minimum_applicant_age", null: false
+    t.integer "maximum_applicant_age", null: false
     t.index ["insurer_id"], name: "index_products_on_insurer_id"
     t.index ["name"], name: "index_products_on_name", unique: true
   end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :product do
     name { Faker::Company.unique.name }
     customer_type { 'individual' }
+    minimum_applicant_age { 18 }
+    maximum_applicant_age { 80 }
     insurer
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Product, type: :model do
   it { expect(product).to belong_to :insurer }
   it { expect(product).to validate_presence_of :name }
   it { expect(product).to validate_uniqueness_of(:name).case_insensitive }
+  it { expect(product).to validate_presence_of :minimum_applicant_age }
+  it { expect(product).to validate_presence_of :maximum_applicant_age }
   it { expect(product).to validate_presence_of :insurer }
   it { expect(product).to have_many(:product_modules).dependent(:destroy) }
   it { expect(product).to define_enum_for(:customer_type).with_values(%w[individual corporate]) }

--- a/spec/policies/suitable_health_product_policy_spec.rb
+++ b/spec/policies/suitable_health_product_policy_spec.rb
@@ -1,12 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe SuitableHealthProductPolicy do
-  let(:suitable_health_product_policy) { described_class.new(health_product, required_coverages).allowed? }
+  let(:suitable_health_product_policy) do
+    described_class.new(health_product,
+                        required_coverages: required_coverages,
+                        main_applicant_age: main_applicant_age,
+                        dependants_ages: dependants_ages).allowed?
+  end
+  let(:required_coverages) { %w[inpatient] }
+  let(:main_applicant_age) { 18 }
+  let(:dependants_ages) { [18, 5, 3] }
   let(:health_product) do
     ComparisonProduct.new(insurer: insurer, product: product, product_modules: product_modules)
   end
   let(:insurer) { create(:insurer) }
-  let(:product) { create(:product, insurer: insurer) }
+  let(:product) { create(:product, minimum_applicant_age: 18, maximum_applicant_age: 80, insurer: insurer) }
+  let(:product_modules) { [core_module] }
+  let(:core_module) do
+    create(:product_module) do |product_module|
+      create(:coverage_area, product_module: product_module)
+    end
+  end
 
   describe('#allowed?') do
     context 'when the health_product does not have the required coverage areas' do
@@ -63,6 +77,46 @@ RSpec.describe SuitableHealthProductPolicy do
       let(:required_coverages) { %w[inpatient outpatient] }
 
       it 'returns false when the required coverages does not include outpatient' do
+        expect(suitable_health_product_policy).to be false
+      end
+    end
+
+    context 'when the main applicnats age is between the health products minimum and maximum age' do
+      let(:main_applicant_age) { 30 }
+
+      it 'returns true' do
+        expect(suitable_health_product_policy).to be true
+      end
+    end
+
+    context 'when the main applicants age is less than the health products minimum age' do
+      let(:main_applicant_age) { 17 }
+
+      it 'returns false' do
+        expect(suitable_health_product_policy).to be false
+      end
+    end
+
+    context 'when the main applicants age is greater than the health products maximum age' do
+      let(:main_applicant_age) { 81 }
+
+      it 'returns false' do
+        expect(suitable_health_product_policy).to be false
+      end
+    end
+
+    context 'when all the dependants ages are below the health products maximum age' do
+      let(:dependants_ages) { [25, 5, 3] }
+
+      it 'returns true' do
+        expect(suitable_health_product_policy).to be true
+      end
+    end
+
+    context 'when any of the dependants ages are over the products maximum age' do
+      let(:dependants_ages) { [81, 5, 3] }
+
+      it 'returns false' do
         expect(suitable_health_product_policy).to be false
       end
     end

--- a/spec/services/matched_coverage_comparison_products_spec.rb
+++ b/spec/services/matched_coverage_comparison_products_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe MatchedCoverageComparisonProducts do
-  subject(:matched_coverage_comparison_products) { described_class.new(required_coverages, comparison_products) }
+  subject(:matched_coverage_comparison_products) do
+    described_class.new(comparison_products,
+                        required_coverages: required_coverages,
+                        main_applicant_age: main_applicant_age,
+                        dependants_ages: dependants_ages)
+  end
 
   let(:comparison_products) { [comparison_product] }
   let(:comparison_product) do
@@ -9,6 +14,8 @@ RSpec.describe MatchedCoverageComparisonProducts do
   end
   let(:insurer) { create(:insurer) }
   let(:product) { create(:product, insurer: insurer) }
+  let(:main_applicant_age) { 18 }
+  let(:dependants_ages) { [18, 3, 2] }
 
   context 'with only inpatient coverage required' do
     let(:required_coverages) { %w[inpatient] }


### PR DESCRIPTION
Because: A health product should only be recommended to a user when
applicants are within the permitted ages to apply

This commit:
- Refactor matched coverage product to accept keyword arguments
- Add main applicant age check to suitable product policy
- Add migration to add minimum and maximum age to products table
- Add minimum and maximum applicant ages to product factory
- Update suitable health product policy to check main applicant age and dependants ages are valid
- Delegate minimum_applicant_age and maximum_applicant_age in ComparisonProduct to the product
- Update MatchedCoverageComparisonProducts to accept and pass main_applicant_age and dependants_ages to suitable policy
- add presence validations to minimum and maximum age columns on Product