### PR TITLE
Separate evacuation and repatriation into separate coverage areas

### DIFF
--- a/app/models/coverage_area.rb
+++ b/app/models/coverage_area.rb
@@ -1,6 +1,6 @@
 class CoverageArea < ApplicationRecord
   enum category: { inpatient: 0, outpatient: 1, medicines_and_appliances: 3, maternity: 4,
-                   evacuation_and_repatriation: 5, wellness: 6, dental: 7, optical: 8 }
+                   evacuation: 5, wellness: 6, dental: 7, optical: 8, repatriation: 9 }
 
   belongs_to :product_module
 

--- a/spec/models/coverage_area_spec.rb
+++ b/spec/models/coverage_area_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe CoverageArea, type: :model do
   it do
     expect(coverage_area).to define_enum_for(:category)
       .with_values(inpatient: 0, outpatient: 1, medicines_and_appliances: 3, maternity: 4,
-                   evacuation_and_repatriation: 5, wellness: 6, dental: 7, optical: 8)
+                   evacuation: 5, wellness: 6, dental: 7, optical: 8, repatriation: 9)
   end
 end

--- a/spec/services/comparison_product_spec.rb
+++ b/spec/services/comparison_product_spec.rb
@@ -151,13 +151,13 @@ RSpec.describe ComparisonProduct do
           create(:coverage_area, category: :outpatient, product_module: product_module)
         end,
         create(:product_module) do |product_module|
-          create(:coverage_area, category: :evacuation_and_repatriation, product_module: product_module)
+          create(:coverage_area, category: :evacuation, product_module: product_module)
         end
       ]
     end
 
     context 'when the product modules have coverage areas that have categories that match those passed in' do
-      let(:coverages) { %w[inpatient outpatient evacuation_and_repatriation] }
+      let(:coverages) { %w[inpatient outpatient evacuation] }
 
       it 'returns true' do
         expect(comparison_product.coverage_areas?(coverages)).to be true

--- a/spec/services/suitable_health_products_spec.rb
+++ b/spec/services/suitable_health_products_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe SuitableHealthProducts do
   end
 
   context 'with many required coverages' do
-    let(:required_coverages) { %w[inpatient outpatient evacuation_and_repatriation dental] }
+    let(:required_coverages) { %w[inpatient outpatient evacuation dental] }
 
     context 'when covered under a single module' do
       let(:product_modules) { [module_with_multiple_coverage_areas] }
@@ -159,7 +159,7 @@ RSpec.describe SuitableHealthProducts do
         create(:product_module) do |product_module|
           create(:coverage_area, category: 'inpatient', product_module: product_module)
           create(:coverage_area, category: 'outpatient', product_module: product_module)
-          create(:coverage_area, category: 'evacuation_and_repatriation', product_module: product_module)
+          create(:coverage_area, category: 'evacuation', product_module: product_module)
           create(:coverage_area, category: 'dental', product_module: product_module)
         end
       end
@@ -187,7 +187,7 @@ RSpec.describe SuitableHealthProducts do
       end
       let!(:evacuation_module) do
         create(:product_module, category: 'evacuation_and_repatriation', product: product) do |product_module|
-          create(:coverage_area, category: 'evacuation_and_repatriation', product_module: product_module)
+          create(:coverage_area, category: 'evacuation', product_module: product_module)
         end
       end
       let!(:dental_module) do
@@ -207,14 +207,14 @@ RSpec.describe SuitableHealthProducts do
   end
 
   context 'when a module has a coverage option which the user has not selected and is not outpatient' do
-    let(:required_coverages) { %w[inpatient evacuation_and_repatriation] }
+    let(:required_coverages) { %w[inpatient evacuation] }
 
     context 'when under the core module' do
       let(:product_modules) { [core_module] }
       let(:core_module) do
         create(:product_module) do |product_module|
           create(:coverage_area, category: 'inpatient', product_module: product_module)
-          create(:coverage_area, category: 'evacuation_and_repatriation', product_module: product_module)
+          create(:coverage_area, category: 'evacuation', product_module: product_module)
         end
       end
 
@@ -236,7 +236,7 @@ RSpec.describe SuitableHealthProducts do
       end
       let!(:evacuation_module) do
         create(:product_module, category: 'evacuation_and_repatriation', product: product) do |product_module|
-          create(:coverage_area, category: 'evacuation_and_repatriation', product_module: product_module)
+          create(:coverage_area, category: 'evacuation', product_module: product_module)
         end
       end
 


### PR DESCRIPTION
Because some product modules cover evacuation and repatriation separately

This commit:
- Separates evacuation and repatriation into separate coverage areas